### PR TITLE
Updated readme instructions so that they work out of the box.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Contains a dockerfile to run our database in a contained environment, along with
 
 Get [docker](http://docker.com).
 
-Build the container using
+Build the container from the FAForever/db-directory using
 
     docker build -t faf-db .
 
@@ -14,6 +14,19 @@ Run using
 
     docker run -d --name faf-db -e MYSQL_ROOT_PASSWORD=<wanted_password> faf-db
 
-Import Structure
+Create database
 
-    docker exec -i faf-db mysql -uroot -p<wantedpassword> < db-structure.sql
+    docker exec -i faf-db mysql -uroot -p<wantedpassword> -e "create database <wanteddatabase>"
+
+Import structure
+
+    docker exec -i faf-db mysql -uroot -p<wantedpassword> <wanteddatabase> < db-structure.sql
+
+Import data
+
+    docker exec -i faf-db mysql -uroot -p<wantedpassword> <wanteddatabase> < db-data.sql
+
+
+# Side notes
+
+Using the docker build process will provide you with the required software versions. If you decide to run the database outside docker you will require a MySQL version >= 5.6.5.


### PR DESCRIPTION
For developers who haven't worked with docker (like me) the instructions should work out of the box. So I digged into it and added the missing statements.

If have further added the hint for the MySQL version, because I tried to host the database on my Synology NAS, which has a very old MariaDB version. On old versions, you may run into the error 
> #1293 - Incorrect table definition; there can be only one TIMESTAMP column with CURRENT_TIMESTAMP in DEFAULT or ON UPDATE clause

on importing data-structure.sql.