### PR TITLE
Add table `teamkills` for server-issue #95

### DIFF
--- a/db-structure.sql
+++ b/db-structure.sql
@@ -1268,6 +1268,21 @@ CREATE TABLE IF NOT EXISTS `table_mod` (
 ) ENGINE=InnoDB AUTO_INCREMENT=798 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+-- -----------------------------------------------------
+-- Table `teamkills`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `teamkills` (
+  `teamkiller` INT UNSIGNED NOT NULL COMMENT 'login of the player who performed the teamkill',
+  `victim` INT UNSIGNED NOT NULL COMMENT 'login of the player who got teamkilled and reported the tk',
+  `game_id` int(10) unsigned NOT NULL COMMENT 'game-id where teamkill was performed',
+  `gametime` mediumint(8) unsigned NOT NULL COMMENT 'time of game in seconds when tk was performed',
+  `reported_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX (game_id)
+) ENGINE = InnoDB;
+
 --
 -- Table structure for table `test`
 --

--- a/faf/db/tables.py
+++ b/faf/db/tables.py
@@ -429,6 +429,16 @@ class TableMod(Base):
     ranked = Column(Integer, nullable=False, server_default=text("'0'"))
 
 
+class Teamkill(Base):
+    __tablename__ = 'teamkills'    
+
+    teamkiller = Column(Integer, nullable=False)   
+    victim = Column(Integer, nullable=False)
+    game_id = Column(Integer, nullable=False)
+    gametime = Column(Integer, nullable=False)
+    reported_at = Column(DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP"))
+
+
 class TutorialSection(Base):
     __tablename__ = 'tutorial_sections'
 

--- a/migrations/add_teamkills-ab3d56fe949550d2ac113a148582e4c7c690e25c.sql
+++ b/migrations/add_teamkills-ab3d56fe949550d2ac113a148582e4c7c690e25c.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS `teamkills` (
+  `teamkiller` mediumint(8) unsigned NOT NULL COMMENT 'login of the player who performed the teamkill',
+  `victim` mediumint(8) unsigned NOT NULL COMMENT 'login of the player who got teamkilled and reported the tk',
+  `game_id` int(10) unsigned NOT NULL COMMENT 'game-id where teamkill was performed',
+  `gametime` mediumint(8) unsigned NOT NULL COMMENT 'time of game in seconds when tk was performed',
+  `reported_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX (game_id));


### PR DESCRIPTION
Prerequisite to work on https://github.com/FAForever/server/issues/95
Table structure is based upon the new GPGNet-command from https://github.com/FAForever/fa/pull/903