### PR TITLE
Clean up map tables

### DIFF
--- a/db-data.sql
+++ b/db-data.sql
@@ -290,24 +290,45 @@ delete from version_lobby;
 insert into version_lobby (id, `file`, version) values (1, 'some-installer.msi', '0.10.125');
 
 -- Sample maps
-delete from table_map;
-insert into table_map (id, filename, `mapuid`)
+delete from map;
+insert into map (id, display_name, map_type, battle_type, uploader)
 values
-(1, 'scmp_001/scmp_001.scenario_info.lua', 1),
-(2, 'scmp_002/scmp_002.scenario_info.lua', 2),
-(3, 'scmp_003/scmp_003.scenario_info.lua', 3),
-(4, 'scmp_004/scmp_004.scenario_info.lua', 4),
-(5, 'scmp_005/scmp_005.scenario_info.lua', 5),
-(6, 'scmp_006/scmp_006.scenario_info.lua', 6),
-(7, 'scmp_007/scmp_007.scenario_info.lua', 7),
-(8, 'scmp_008/scmp_008.scenario_info.lua', 8),
-(9, 'scmp_009/scmp_009.scenario_info.lua', 9),
-(10, 'scmp_010/scmp_010.scenario_info.lua', 11),
-(11, 'scmp_011/scmp_011.scenario_info.lua', 12),
-(12, 'scmp_012/scmp_012.scenario_info.lua', 13),
-(13, 'scmp_013/scmp_014.scenario_info.lua', 14),
-(14, 'scmp_014/scmp_014.scenario_info.lua', 15),
-(15, 'scmp_015/scmp_015.scenario_info.lua', 16);
+(1, 'SCMP_001', 'FFA', 'skirmish', 1),
+(2, 'SCMP_002', 'FFA', 'skirmish', 1),
+(3, 'SCMP_003', 'FFA', 'skirmish', 1),
+(4, 'SCMP_004', 'FFA', 'skirmish', 1),
+(5, 'SCMP_005', 'FFA', 'skirmish', 1),
+(6, 'SCMP_006', 'FFA', 'skirmish', 2),
+(7, 'SCMP_007', 'FFA', 'skirmish', 2),
+(8, 'SCMP_008', 'FFA', 'skirmish', 2),
+(9, 'SCMP_009', 'FFA', 'skirmish', 2),
+(10, 'SCMP_010', 'FFA', 'skirmish', 3),
+(11, 'SCMP_011', 'FFA', 'skirmish', 3),
+(12, 'SCMP_012', 'FFA', 'skirmish', 3),
+(13, 'SCMP_013', 'FFA', 'skirmish', 3),
+(14, 'SCMP_014', 'FFA', 'skirmish', 3),
+(15, 'SCMP_015', 'FFA', 'skirmish', 3);
+
+insert into map_version (description, max_players, size_x, size_y, version, filename, hidden, map_id)
+values
+('SCMP 001', 8, 5, 5, 1, 'maps/scmp_001.v0001.zip', 0, 1),
+('SCMP 002', 8, 5, 5, 1, 'maps/scmp_002.v0001.zip', 0, 2),
+('SCMP 003', 8, 5, 5, 1, 'maps/scmp_003.v0001.zip', 0, 3),
+('SCMP 004', 8, 5, 5, 1, 'maps/scmp_004.v0001.zip', 0, 4),
+('SCMP 005', 8, 5, 5, 1, 'maps/scmp_005.v0001.zip', 0, 5),
+('SCMP 006', 8, 5, 5, 1, 'maps/scmp_006.v0001.zip', 0, 6),
+('SCMP 007', 8, 5, 5, 1, 'maps/scmp_007.v0001.zip', 0, 7),
+('SCMP 008', 8, 5, 5, 1, 'maps/scmp_008.v0001.zip', 0, 8),
+('SCMP 009', 8, 5, 5, 1, 'maps/scmp_009.v0001.zip', 0, 9),
+('SCMP 010', 8, 5, 5, 1, 'maps/scmp_010.v0001.zip', 0, 10),
+('SCMP 011', 8, 5, 5, 1, 'maps/scmp_011.v0001.zip', 0, 11),
+('SCMP 012', 8, 5, 5, 1, 'maps/scmp_012.v0001.zip', 0, 12),
+('SCMP 013', 8, 5, 5, 1, 'maps/scmp_013.v0001.zip', 0, 13),
+('SCMP 014', 8, 5, 5, 1, 'maps/scmp_014.v0001.zip', 0, 14),
+('SCMP 015', 8, 5, 5, 1, 'maps/scmp_015.v0001.zip', 0, 15),
+('SCMP 015', 8, 5, 5, 2, 'maps/scmp_015.v0002.zip', 0, 15),
+('SCMP 015', 8, 10, 10, 3, 'maps/scmp_015.v0003.zip', 0, 15);
+
 
 -- game_stats table
 delete from game_stats;

--- a/db-structure.sql
+++ b/db-structure.sql
@@ -1157,30 +1157,62 @@ CREATE TABLE IF NOT EXISTS `swiss_tournaments_players` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `table_map`
+-- Table structure for table `map`
 --
 
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE IF NOT EXISTS `table_map` (
+CREATE TABLE IF NOT EXISTS `map` (
   `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(40) DEFAULT NULL,
-  `description` longtext,
-  `max_players` decimal(2,0) DEFAULT NULL,
-  `map_type` varchar(15) DEFAULT NULL,
-  `battle_type` varchar(15) DEFAULT NULL,
-  `map_sizeX` decimal(4,0) DEFAULT NULL,
-  `map_sizeY` decimal(4,0) DEFAULT NULL,
-  `version` decimal(4,0) DEFAULT NULL,
-  `filename` varchar(200) DEFAULT NULL,
-  `hidden` tinyint(1) NOT NULL DEFAULT '0',
-  `mapuid` mediumint(8) unsigned NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `Combo` (`name`,`version`),
-  UNIQUE KEY `map_filename` (`filename`),
-  KEY `mapuid` (`mapuid`)
-) ENGINE=InnoDB AUTO_INCREMENT=5692 DEFAULT CHARSET=latin1;
+  `display_name` varchar(40) NOT NULL UNIQUE,
+  `map_type` varchar(15) NOT NULL,
+  `battle_type` varchar(15) NOT NULL,
+  `ranked` tinyint(1) NOT NULL DEFAULT 1,
+  `uploader` mediumint(8) unsigned NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `map_version`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE IF NOT EXISTS `map_version` (
+  `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `description` longtext,
+  `max_players` decimal(2,0) NOT NULL,
+  `size_x` decimal(4,0) NOT NULL,
+  `size_y` decimal(4,0) NOT NULL,
+  `version` decimal(4,0) NOT NULL,
+  `filename` varchar(200) NOT NULL UNIQUE,
+  `hidden` tinyint(1) NOT NULL DEFAULT 0,
+  `map_id` mediumint(8) unsigned NOT NULL,
+  UNIQUE KEY `map_id_version` (`map_id`, `version`),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+
+
+--
+-- Create view `table_map` for backwards compatibility
+--
+CREATE VIEW table_map AS (select
+        m.id,
+        m.display_name as name,
+        m.map_type,
+        m.battle_type,
+        v.description,
+        v.version,
+        v.filename,
+        v.hidden,
+        v.max_players,
+        v.size_x as map_sizeX,
+        v.size_y as map_sizeY
+    from map m
+    join map_version v on m.id = v.map_id);
 
 --
 -- Table structure for table `table_map_broken`
@@ -1238,17 +1270,6 @@ CREATE TABLE IF NOT EXISTS `table_map_features` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
---
--- Table structure for table `table_map_unranked`
---
-
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE IF NOT EXISTS `table_map_unranked` (
-  `id` int(10) unsigned NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `table_map_uploaders`

--- a/migrations/map_table_cleanup-d1b06336b2245b0b719d6b5e2ccb97484e3ccab2.sql
+++ b/migrations/map_table_cleanup-d1b06336b2245b0b719d6b5e2ccb97484e3ccab2.sql
@@ -1,0 +1,70 @@
+START TRANSACTION;
+
+-- Merge `table_map_unranked` into `table_map.ranked`, drop the old table
+alter table table_map add `ranked` tinyint(1) NOT NULL DEFAULT 1;
+update table_map m set ranked = 0 where exists (select id from table_map_unranked tmu where tmu.id = m.id);
+drop table table_map_unranked;
+
+-- Merge `table_map_uploaders` into `table_map.uploader`, drop the old table
+alter table table_map add `uploader` mediumint(8) unsigned;
+update table_map m set uploader = (select id from table_map_uploaders up where up.mapid = m.id);
+drop table table_map_uploaders;
+
+-- split it into `map` and `map_version`, create a view for backwards compatibility
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `map_version` (
+  `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `description` longtext,
+  `max_players` decimal(2,0) NOT NULL,
+  `size_x` decimal(4,0) NOT NULL,
+  `size_y` decimal(4,0) NOT NULL,
+  `version` decimal(4,0) NOT NULL,
+  `filename` varchar(200) NOT NULL UNIQUE,
+  `hidden` tinyint(1) NOT NULL DEFAULT 0,
+  `map_id` mediumint(8) unsigned NOT NULL,
+  UNIQUE KEY `map_id_version` (`map_id`, `version`),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+rename table table_map TO map;
+update map set name = CONCAT('Name',id) where name IS NULL;
+update map set map_type = 'FFA' where map_type IS NULL;
+update map set battle_type = 'skirmish' where battle_type IS NULL;
+
+insert into map_version (id, description, max_players, size_x, size_y, version, filename, hidden, map_id)
+    select id, COALESCE(description, 'None'), COALESCE(max_players, 0), COALESCE(map_sizeX, 0), COALESCE(map_sizeY, 0), COALESCE(version, 1), filename, hidden, id
+    from map;
+
+update map_version set map_id = (select id from map where name = (select name from map where id = map_id) order by version desc limit 1);
+
+delete m1 from `map` m1, `map` m2 where m1.version < m2.version and m1.name = m2.name;
+alter table map change name display_name varchar(40) NOT NULL UNIQUE;
+alter table map MODIFY map_type varchar(15) NOT NULL;
+alter table map MODIFY battle_type varchar(15) NOT NULL;
+alter table map drop mapuid;
+alter table map drop description;
+alter table map drop max_players;
+alter table map drop map_sizeX;
+alter table map drop map_sizeY;
+alter table map drop version;
+alter table map drop filename;
+alter table map drop hidden;
+
+CREATE VIEW table_map AS (select
+        m.id,
+        m.display_name as name,
+        m.map_type,
+        m.battle_type,
+        v.description,
+        v.version,
+        v.filename,
+        v.hidden,
+        v.max_players,
+        v.size_x as map_sizeX,
+        v.size_y as map_sizeY
+    from map m
+    join map_version v on m.id = v.map_id);
+
+COMMIT;

--- a/test_scripts.sh
+++ b/test_scripts.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <test_rev>"
+  echo "    <test_rev>  The previous DB revision to test against"
+  echo
+  echo "Example: $0 \$(git rev-parse HEAD)"
+  exit 1
+fi
+
+db=faf_test
+pw=banana
+previousRev=$1
+
+docker exec -i faf-db mysql -p${pw} ${db} -e "drop database ${db}; create database ${db}" \
+&& git cat-file -p ${previousRev}:db-structure.sql | docker exec -i faf-db mysql -p${pw} ${db} \
+&& git cat-file -p ${previousRev}:db-data.sql | docker exec -i faf-db mysql -p${pw} ${db} \
+&& docker exec -i faf-db mysql -p${pw} ${db} < migrations/*${previousRev}.sql \
+&& docker exec -i faf-db mysql -p${pw} ${db} < db-data.sql
+
+exit $?


### PR DESCRIPTION
* Split `table_map` into `map` and `map_version`
* Merge `table_map_unranked` into `map.ranked`
* Merge `table_map_uploaders` into `map.uploader`
* Create view `table_map` for backwards compatibility
* Add `test_migration.sh` for easy (currently manual) testing of new SQL scripts