### PR TITLE
Add more null constraints to lobby_ban

### DIFF
--- a/db-structure.sql
+++ b/db-structure.sql
@@ -773,9 +773,9 @@ CREATE TABLE IF NOT EXISTS `lobby_admin` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE IF NOT EXISTS `lobby_ban` (
-  `idUser` mediumint(8) unsigned DEFAULT NULL,
+  `idUser` mediumint(8) unsigned NOT NULL,
   `reason` varchar(255) NOT NULL,
-  `expires_at` datetime DEFAULT NULL COMMENT 'When the ban expires',
+  `expires_at` datetime NOT NULL DEFAULT '2222-07-21' COMMENT 'When the ban expires',
   UNIQUE KEY `idUser` (`idUser`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/migrations/nonnull_bans-2ee16b581c35a43bfb5e831e42728bb66dea5ce5.sql
+++ b/migrations/nonnull_bans-2ee16b581c35a43bfb5e831e42728bb66dea5ce5.sql
@@ -1,0 +1,9 @@
+-- These are garbage
+DELETE FROM lobby_ban WHERE idUser IS NULL;
+
+-- Represent infinite bans with large numbers, not NULL.
+UPDATE lobby_ban SET expires_at = '2222-07-21' WHERE expires_at IS NULL;
+
+ALTER TABLE lobby_ban 
+    MODIFY expires_at datetime NOT NULL DEFAULT '2222-07-21',
+    MODIFY idUser mediumint(8) unsigned NOT NULL;


### PR DESCRIPTION
Represent infinite bans as 200-year bans instead. The new default
for this field is this, to retain compatibility with code that
doesn't specify the field.

Prune bans with null user id, because WTF.