### PR TITLE
Add optional schema dump to setup_db.sh for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ services:
   - docker
 
 script:
-  - ./setup_db.sh
+  - ./setup_db.sh -d

--- a/setup_db.sh
+++ b/setup_db.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+DUMPSCHEMA=
+
+while getopts ":d" opt; do
+  case $opt in
+    d)
+      DUMPSCHEMA=1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
+
 # Builds and runs the faf-db image in a new container and waits until it initialized
 
 docker build -t faf-db .
@@ -17,5 +30,9 @@ docker exec -i ${DB_CONTAINER} mysql -uroot -pbanana -e "create database faf_tes
 echo "y
 n
 " | ./migrate.sh faf-db || exit 1;
+
+if [ $DUMPSCHEMA ]; then
+  docker exec -i ${DB_CONTAINER} mysqldump -uroot -pbanana --no-data faf_test || exit 1;
+fi
 
 docker exec -i ${DB_CONTAINER} mysql -uroot -pbanana faf_test < db-data.sql || exit 1;


### PR DESCRIPTION
* Add `-d` for "dump schema" option to `setup_db.sh`
* Use `-d` in travis build

This PR does a schema dump after the migrations are finished so the whole db schema (that isn't noted anywhere since it consists of base + all migrations) is easily accessible.

Could be refined by turning it into a build artifact and uploading to somewhere.