### PR TITLE
Fix #85 timestamp columns cannot be null

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql:5.7.18
 
 ENV FLYWAY_VERSION 4.0.3
 


### PR DESCRIPTION
Version upgrade from `5.7.16` to `5.7.17` or `5.7.18` solved the problem ...

no real idea why
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-17.html

Fix #85 timestamp columns cannot be null
