### PR TITLE
Fix #87 add featured mod constraint

### DIFF
--- a/migrations/V32__featured-mod-constraint.sql
+++ b/migrations/V32__featured-mod-constraint.sql
@@ -1,0 +1,16 @@
+# Estimated script run time: 25min
+
+# As voted for by Sheeo, Brutus5000, and Yenon, we delete games we no longer have featured mods for.
+# Alternatively, we'd have to create dummy featuredMod entries.
+DELETE FROM game_player_stats
+WHERE gameId IN (SELECT id
+                 FROM game_stats
+                 WHERE gameMod NOT IN (SELECT id
+                                       FROM game_featuredMods));
+
+DELETE FROM game_stats
+WHERE gameMod NOT IN (SELECT id
+                      FROM game_featuredMods);
+
+ALTER TABLE game_stats
+  ADD CONSTRAINT game_stats_game_featuredMods_id_fk FOREIGN KEY (gameMod) REFERENCES game_featuredMods (id);


### PR DESCRIPTION
Removes all games for which we lost the "featured mod" information
(some featured mods were removed with the March 2017 server update) and
and adds a constraint so this may never happen again.