### PR TITLE
Create /root/.my.cnf with db credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,11 @@ RUN chmod +x dump-structure.sh
 # Copy test data for CI
 COPY test-data.sql /
 
+# Copy pre-init script
+COPY pre-entry.sh /usr/local/bin/docker-pre-entry.sh
+RUN chmod +x /usr/local/bin/docker-pre-entry.sh
+ENTRYPOINT ["docker-pre-entry.sh"]
+# CMD has to be specified again after new ENTRYPOINT (https://docs.docker.com/engine/reference/builder/#entrypoint)
+CMD ["mysqld"]
+
 EXPOSE 3306

--- a/pre-entry.sh
+++ b/pre-entry.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script is necessary because the mysql entrypoint script won't let use
+# run anything as root.
+
+# Put mysql root pw into /root/.my.cnf
+# This allows docker exec -it faf-db mysql to work without having to pass or enter password
+#mysql_config_editor set --login-path=faf_lobby --host=localhost --user=root --password
+cat > /root/.my.cnf <<LOGIN_CNF
+[client]
+user = root
+password = ${MYSQL_ROOT_PASSWORD}
+host = localhost
+database = faf
+LOGIN_CNF
+
+# Now run the real script
+docker-entrypoint.sh $@

--- a/test-migrations.sh
+++ b/test-migrations.sh
@@ -2,10 +2,10 @@
 set -e
 echo -e 'travis_fold:start:Start Migration Base Test'
 echo '# Start Migration Base Test...'
-docker exec -i faf-db mysql -uroot -pbanana <<< "DROP DATABASE faf;"
-docker exec -i faf-db mysql -uroot -pbanana <<< "CREATE DATABASE faf;"
+docker exec -i faf-db mysql --no-defaults -uroot -pbanana <<< "DROP DATABASE faf;"
+docker exec -i faf-db mysql --no-defaults -uroot -pbanana <<< "CREATE DATABASE faf;"
 echo 'Import dump ...'
-docker exec -i faf-db mysql -uroot -pbanana faf < ./faf-db-dump/dump.sql
+docker exec -i faf-db mysql --no-defaults -uroot -pbanana faf < ./faf-db-dump/dump.sql
 echo 'Migrate ...'
 docker exec -i faf-db ./migrate.sh
 


### PR DESCRIPTION
Allows exec'ing into mysql without having to pass credentials

Having database passwords on the commandline and even in scripts is bad. This way the password is read from the config file.

This doesn't make anything any less secure, since the db root pw is in an env var inside the container anyway.