### PR TITLE
Remove database setting from .my.cnf

### DIFF
--- a/pre-entry.sh
+++ b/pre-entry.sh
@@ -11,7 +11,6 @@ cat > /root/.my.cnf <<LOGIN_CNF
 user = root
 password = ${MYSQL_ROOT_PASSWORD}
 host = localhost
-database = faf
 LOGIN_CNF
 
 # Now run the real script


### PR DESCRIPTION
It confuses mysqldump and isn't useful right now anyway...

Presumably this is a bug in mysqldump:

```
faforever@brackman:/opt$ docker exec -i faf-db mysqldump faf_lobby > /opt/dumps/faf_lobby-$(date +"%Y-%m-%d-%H-%M-%S").sql
mysqldump: [ERROR] unknown variable 'database=faf'
```