### PR TITLE
Add validity states for coop leaderboards

### DIFF
--- a/migrations/V63__coop-validity-states.sql
+++ b/migrations/V63__coop-validity-states.sql
@@ -1,5 +1,5 @@
 INSERT INTO game_validity (id, message) VALUES
   (20, 'Civilians were revealed'),
-  (21, 'Difficulty was too low'),
+  (21, 'Difficulty was wrong'),
   (22, 'Expansion was disabled'),
   (23, 'Team spawn was not fixed');

--- a/migrations/V63__coop-validity-states.sql
+++ b/migrations/V63__coop-validity-states.sql
@@ -2,4 +2,5 @@ INSERT INTO game_validity (id, message) VALUES
   (20, 'Civilians were revealed'),
   (21, 'Difficulty was wrong'),
   (22, 'Expansion was disabled'),
-  (23, 'Team spawn was not fixed');
+  (23, 'Team spawn was not fixed'),
+  (24, 'Unranked for another reason');

--- a/migrations/V63__coop-validity-states.sql
+++ b/migrations/V63__coop-validity-states.sql
@@ -1,0 +1,5 @@
+INSERT INTO game_validity (id, message) VALUES
+  (20, 'Civilians were revealed'),
+  (21, 'Difficulty was too low'),
+  (22, 'Expansion was disabled'),
+  (23, 'Team spawn was not fixed');


### PR DESCRIPTION
Some additional reasons why a coop game may be considered 'unranked' and will not be inserted into the leaderboard.

Other projects that need updating:
  * [ ] ~~Faf Tools~~ <-- Is super outdated, and unused
  * [x] Python server https://github.com/FAForever/server/pull/388
  * [x] Python Client <-- Doesn't need update. It doesn't care about these values
  * [x] Java Commons https://github.com/FAForever/faf-java-commons/pull/23
  * [x] Java Api **<!-- Does NOT use Java Commons... Why?** https://github.com/FAForever/faf-java-api/pull/303
  * [x] Java Server **<!-- Does NOT use Java Commons... Why?** https://github.com/FAForever/faf-java-server/pull/111
  * [x] Moderator client <-- Uses Java Commons
  * [x] Java Client **<!-- Does NOT use Java Commons... Why?** https://github.com/FAForever/downlords-faf-client/pull/1093