### PR TITLE
Add field to game_stats for storing in-game length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,6 @@ python: "3.6"
 services:
   - docker
 
-addons:
-  apt:
-    sources:
-    - mysql-5.7-trusty
-    packages:
-    - mysql-client
-
 before_script:
   - sudo /etc/init.d/mysql stop
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM boxfuse/flyway:5.2.0-alpine
+FROM boxfuse/flyway:5.2-alpine
 
 ENV FLYWAY_EDITION community
 

--- a/migrations/V71__game_durations.sql
+++ b/migrations/V71__game_durations.sql
@@ -1,0 +1,4 @@
+ALTER TABLE game_stats
+  ADD replay_ticks INT UNSIGNED DEFAULT NULL
+  COMMENT "The total number of ticks present in the replay. The SCFA tick rate is 10 ticks/second"
+    AFTER endTime;

--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,7 @@ counter=1
 # wait 5 minutes on docker container
 while [ $counter -le 300 ]
 do
-    if mysqladmin ping -h 127.0.0.1 -uroot -pbanana 2> /dev/null; then
+    if docker exec -it faf-db sh -c "mysqladmin ping -h 127.0.0.1 -uroot -pbanana" 2> /dev/null; then
         echo -en 'travis_fold:end:docker\\r'
 
         # run flyway migrations


### PR DESCRIPTION
With some changes across the replay server, API and client this should make vault displayed game lengths align perfectly with in game times. This will help remediate countless issues like this one:
https://github.com/FAForever/server/issues/346

That being said, I still would like the server game ending logic to get fixed so that we can have an accurate measurement of real time elapsed as well. For example, it would be interesting to browse the vault and compare in game lengths to real time elapsed. Although, I suspect that when people are browsing the vault, they care less about the real time elapsed than they do the actual game time.