### PR TITLE
Add foreign key to coop leaderboards gameuid

### DIFF
--- a/migrations/V75__coop_leaderboard_foreign_key.sql
+++ b/migrations/V75__coop_leaderboard_foreign_key.sql
@@ -3,5 +3,6 @@ DELETE c FROM coop_leaderboard c
   LEFT JOIN game_stats g ON g.id = c.gameuid
       WHERE g.id IS NULL;
 
+ALTER TABLE coop_leaderboard MODIFY gameuid INT UNSIGNED;
 ALTER TABLE coop_leaderboard
   ADD FOREIGN KEY (gameuid) REFERENCES game_stats(id);

--- a/migrations/V75__coop_leaderboard_foreign_key.sql
+++ b/migrations/V75__coop_leaderboard_foreign_key.sql
@@ -1,0 +1,7 @@
+-- Delete bad values
+DELETE c FROM coop_leaderboard c
+  LEFT JOIN game_stats g ON g.id = c.gameuid
+      WHERE g.id IS NULL;
+
+ALTER TABLE coop_leaderboard
+  ADD FOREIGN KEY (gameuid) REFERENCES game_stats(id);


### PR DESCRIPTION
Apparently the server was able to insert entries into the coop leaderboard that did not have a corresponding entry in the game_stats table. We should also add some logic into the server to only insert for games that have actually started, but this should at least ensure that the database state is consistent. 

Not sure why this foreign key didn't exist already.