### PR TITLE
TMM: Add tables for map pools

### DIFF
--- a/migrations/V82__map_pools.sql
+++ b/migrations/V82__map_pools.sql
@@ -10,9 +10,9 @@ COMMENT="A collection of maps, used by a matchmaker_pool for map selection";
 CREATE TABLE map_pool_maps
 (
     map_pool_id   INT NOT NULL REFERENCES map_pool (id),
-    map_id        INT NOT NULL REFERENCES map_version (id),
-    PRIMARY KEY (map_pool_id, map_id),
-    INDEX (map_id, map_pool_id)
+    map_version_id        INT NOT NULL REFERENCES map_version (id),
+    PRIMARY KEY (map_pool_id, map_version_id),
+    INDEX (map_version_id, map_pool_id)
 );
 
 CREATE TABLE matchmaker_pool_map_pools

--- a/migrations/V82__map_pools.sql
+++ b/migrations/V82__map_pools.sql
@@ -1,3 +1,6 @@
+ALTER TABLE matchmaker_pool RENAME TO matchmaker_queue;
+ALTER TABLE matchmaker_queue COMMENT="A matchmaker queue specifying which featured mod will be played, which map pools will be drawn from, and which leaderboard will be used to look up and update a player''s rating.";
+
 CREATE TABLE map_pool
 (
     id                  INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
@@ -15,12 +18,12 @@ CREATE TABLE map_pool_map_version
     INDEX (map_version_id, map_pool_id)
 );
 
-CREATE TABLE matchmaker_pool_map_pool
+CREATE TABLE matchmaker_queue_map_pool
 (
-    matchmaker_pool_id  INT REFERENCES matchmaker_pool (id),
+    matchmaker_queue_id  INT REFERENCES matchmaker_queue (id),
     map_pool_id         INT NOT NULL REFERENCES map_pool (id),
     min_rating          INT,
     max_rating          INT,
-    PRIMARY KEY (matchmaker_pool_id, map_pool_id),
-    INDEX (map_pool_id, matchmaker_pool_id)
+    PRIMARY KEY (matchmaker_queue_id, map_pool_id),
+    INDEX (map_pool_id, matchmaker_queue_id)
 );

--- a/migrations/V82__map_pools.sql
+++ b/migrations/V82__map_pools.sql
@@ -2,9 +2,6 @@ CREATE TABLE map_pool
 (
     id                  INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name                VARCHAR(255) NOT NULL,
-    matchmaker_pool_id  INT REFERENCES matchmaker_pool (id),
-    min_rating          INT,
-    max_rating          INT,
     create_time         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     update_time         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB
@@ -16,5 +13,14 @@ CREATE TABLE map_pool_maps
     map_id        INT NOT NULL REFERENCES map_version (id),
     PRIMARY KEY (map_pool_id, map_id),
     INDEX (map_id, map_pool_id)
-)
-COMMENT="Map pool many-to-many table";
+);
+
+CREATE TABLE matchmaker_pool_map_pools
+(
+    matchmaker_pool_id  INT REFERENCES matchmaker_pool (id),
+    map_pool_id         INT NOT NULL REFERENCES map_pool (id),
+    min_rating          INT,
+    max_rating          INT,
+    PRIMARY KEY (matchmaker_pool_id, map_pool_id),
+    INDEX (map_pool_id, matchmaker_pool_id)
+);

--- a/migrations/V82__map_pools.sql
+++ b/migrations/V82__map_pools.sql
@@ -1,17 +1,20 @@
 CREATE TABLE map_pool
 (
-    id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    name          VARCHAR(255) NOT NULL,
-    create_time   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    update_time   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) COMMENT="A collection of maps, used by a matchmaker for map selection";
+    id                  INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name                VARCHAR(255) NOT NULL,
+    matchmaker_pool_id  INT REFERENCES matchmaker_pool (id),
+    min_rating          INT,
+    max_rating          INT,
+    create_time         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB
+COMMENT="A collection of maps, used by a matchmaker_pool for map selection";
 
 CREATE TABLE map_pool_maps
 (
-    map_pool_id   INT REFERENCES map_pool (id),
-    map_id        INT REFERENCES map_version (id),
-    PRIMARY KEY (map_pool_id, map_id)
-) COMMENT="Map pool many-to-many table";
-
-ALTER TABLE matchmaker_pool
-    ADD COLUMN active_map_pool_id  INT REFERENCES map_pool (id);
+    map_pool_id   INT NOT NULL REFERENCES map_pool (id),
+    map_id        INT NOT NULL REFERENCES map_version (id),
+    PRIMARY KEY (map_pool_id, map_id),
+    INDEX (map_id, map_pool_id)
+)
+COMMENT="Map pool many-to-many table";

--- a/migrations/V82__map_pools.sql
+++ b/migrations/V82__map_pools.sql
@@ -1,7 +1,7 @@
 CREATE TABLE map_pool
 (
     id                  INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    name                VARCHAR(255) NOT NULL,
+    name                VARCHAR(255) NOT NULL COMMENT "Only to help admins with organization. Don't show this to the user.",
     create_time         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     update_time         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB

--- a/migrations/V82__map_pools.sql
+++ b/migrations/V82__map_pools.sql
@@ -7,7 +7,7 @@ CREATE TABLE map_pool
 ) ENGINE=InnoDB
 COMMENT="A collection of maps, used by a matchmaker_pool for map selection";
 
-CREATE TABLE map_pool_maps
+CREATE TABLE map_pool_map_version
 (
     map_pool_id   INT NOT NULL REFERENCES map_pool (id),
     map_version_id        INT NOT NULL REFERENCES map_version (id),
@@ -15,7 +15,7 @@ CREATE TABLE map_pool_maps
     INDEX (map_version_id, map_pool_id)
 );
 
-CREATE TABLE matchmaker_pool_map_pools
+CREATE TABLE matchmaker_pool_map_pool
 (
     matchmaker_pool_id  INT REFERENCES matchmaker_pool (id),
     map_pool_id         INT NOT NULL REFERENCES map_pool (id),

--- a/migrations/V82__map_pools.sql
+++ b/migrations/V82__map_pools.sql
@@ -1,0 +1,17 @@
+CREATE TABLE map_pool
+(
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name          VARCHAR(255) NOT NULL,
+    create_time   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) COMMENT="A collection of maps, used by a matchmaker for map selection";
+
+CREATE TABLE map_pool_maps
+(
+    map_pool_id   INT REFERENCES map_pool (id),
+    map_id        INT REFERENCES map_version (id),
+    PRIMARY KEY (map_pool_id, map_id)
+) COMMENT="Map pool many-to-many table";
+
+ALTER TABLE matchmaker_pool
+    ADD COLUMN active_map_pool_id  INT REFERENCES map_pool (id);

--- a/test-data.sql
+++ b/test-data.sql
@@ -47,9 +47,9 @@ DELETE FROM login;
 DELETE FROM email_domain_blacklist;
 DELETE FROM leaderboard;
 DELETE FROM matchmaker_pool;
-DELETE FROM matchmaker_pool_map_pools;
+DELETE FROM matchmaker_pool_map_pool;
 DELETE FROM map_pool;
-DELETE FROM map_pool_maps;
+DELETE FROM map_pool_map_version;
 
 SET FOREIGN_KEY_CHECKS=1;
 
@@ -180,12 +180,12 @@ values (1, "Ladder1v1 season 1: 5-10k"),
        (2, "Ladder1v1 season 1: all"),
        (3, "Large maps");
 
-insert into map_pool_maps (map_pool_id, map_version_id)
+insert into map_pool_map_version (map_pool_id, map_version_id)
 values (1, 15), (1, 16), (1, 17),
        (2, 11), (2, 14), (2, 15), (2, 16), (2, 17),
        (3, 1),  (3, 2),  (3, 3);
 
-insert into matchmaker_pool_map_pools (matchmaker_pool_id, map_pool_id, min_rating, max_rating)
+insert into matchmaker_pool_map_pool (matchmaker_pool_id, map_pool_id, min_rating, max_rating)
 values (1, 1, NULL, 800),
        (1, 2, 800, NULL),
        (1, 3, 1000, NULL),

--- a/test-data.sql
+++ b/test-data.sql
@@ -45,6 +45,11 @@ DELETE FROM name_history;
 DELETE FROM user_group_assignment;
 DELETE FROM login;
 DELETE FROM email_domain_blacklist;
+DELETE FROM leaderboard;
+DELETE FROM matchmaker_pool;
+DELETE FROM matchmaker_pool_map_pools;
+DELETE FROM map_pool;
+DELETE FROM map_pool_maps;
 
 SET FOREIGN_KEY_CHECKS=1;
 
@@ -160,6 +165,31 @@ values (1, 'faf', 'FAF', 'Forged Alliance Forever', 1, 'https://github.com/FAFor
 
 insert into game_stats (id, startTime, gameName, gameType, gameMod, `host`, mapId, validity)
 values (1, NOW(), 'Test game', '0', 6, 1, 1, 0);
+
+insert into leaderboard (id, technical_name, name_key, description_key)
+values (1, "global", "leaderboard.global.name", "leaderboard.global.desc"),
+       (2, "ladder1v1", "leaderboard.ladder1v1.name", "leaderboard.ladder1v1.desc"),
+       (3, "ladder2v2", "leaderboard.ladder2v2.name", "leaderboard.ladder2v2.desc");
+
+insert into matchmaker_pool (id, technical_name, featured_mod_id, leaderboard_id, name_key)
+values (1, "ladder1v1", 1, 1, "matchmaker.ladder1v1"),
+       (2, "ladder2v2", 1, 2, "matchmaker.ladder2v2");
+
+insert into map_pool (id, name)
+values (1, "Ladder1v1 season 1: 5-10k"),
+       (2, "Ladder1v1 season 1: all"),
+       (3, "Large maps");
+
+insert into map_pool_maps (map_pool_id, map_id)
+values (1, 15), (1, 16), (1, 17),
+       (2, 11), (2, 14), (2, 15), (2, 16), (2, 17),
+       (3, 1),  (3, 2),  (3, 3);
+
+insert into matchmaker_pool_map_pools (matchmaker_pool_id, map_pool_id, min_rating, max_rating)
+values (1, 1, NULL, 800),
+       (1, 2, 800, NULL),
+       (1, 3, 1000, NULL),
+       (2, 3, NULL, NULL);
 
 insert into friends_and_foes (user_id, subject_id, `status`)
 values(1, 2, 'FRIEND'),

--- a/test-data.sql
+++ b/test-data.sql
@@ -180,7 +180,7 @@ values (1, "Ladder1v1 season 1: 5-10k"),
        (2, "Ladder1v1 season 1: all"),
        (3, "Large maps");
 
-insert into map_pool_maps (map_pool_id, map_id)
+insert into map_pool_maps (map_pool_id, map_version_id)
 values (1, 15), (1, 16), (1, 17),
        (2, 11), (2, 14), (2, 15), (2, 16), (2, 17),
        (3, 1),  (3, 2),  (3, 3);

--- a/test-data.sql
+++ b/test-data.sql
@@ -46,8 +46,8 @@ DELETE FROM user_group_assignment;
 DELETE FROM login;
 DELETE FROM email_domain_blacklist;
 DELETE FROM leaderboard;
-DELETE FROM matchmaker_pool;
-DELETE FROM matchmaker_pool_map_pool;
+DELETE FROM matchmaker_queue;
+DELETE FROM matchmaker_queue_map_pool;
 DELETE FROM map_pool;
 DELETE FROM map_pool_map_version;
 
@@ -171,7 +171,7 @@ values (1, "global", "leaderboard.global.name", "leaderboard.global.desc"),
        (2, "ladder1v1", "leaderboard.ladder1v1.name", "leaderboard.ladder1v1.desc"),
        (3, "ladder2v2", "leaderboard.ladder2v2.name", "leaderboard.ladder2v2.desc");
 
-insert into matchmaker_pool (id, technical_name, featured_mod_id, leaderboard_id, name_key)
+insert into matchmaker_queue (id, technical_name, featured_mod_id, leaderboard_id, name_key)
 values (1, "ladder1v1", 1, 1, "matchmaker.ladder1v1"),
        (2, "ladder2v2", 1, 2, "matchmaker.ladder2v2");
 
@@ -185,7 +185,7 @@ values (1, 15), (1, 16), (1, 17),
        (2, 11), (2, 14), (2, 15), (2, 16), (2, 17),
        (3, 1),  (3, 2),  (3, 3);
 
-insert into matchmaker_pool_map_pool (matchmaker_pool_id, map_pool_id, min_rating, max_rating)
+insert into matchmaker_queue_map_pool (matchmaker_queue_id, map_pool_id, min_rating, max_rating)
 values (1, 1, NULL, 800),
        (1, 2, 800, NULL),
        (1, 3, 1000, NULL),


### PR DESCRIPTION
For team matchmaking we need to be able to support multiple map pools. This PR adds the ability to create any number of map pools, and set one map pool as the active one for each matchmaker pool. 

Things I'd like some feedback on:
- Should we add a description to `map_pool`? I'm imagining that the name/description of map pools will only serve as a tool to help the admins remember what the map pool was designed for and will never be shown to regular users.
- Should `map_pools_maps` many-to-many table have create/update time? I'm thinking that's probably too much data which will have little value.