### PR TITLE
Add a login log to discover login attack attempts

### DIFF
--- a/migrations/V94__login_log.sql
+++ b/migrations/V94__login_log.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS `login_log` (
+    `id` INT UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT COMMENT 'ID for API/Elide compatibility',
+    `login_id` MEDIUMINT UNSIGNED NOT NULL,
+    `ip` VARCHAR(45) NOT NULL,
+    `attempts` MEDIUMINT UNSIGNED NOT NULL DEFAULT 1,
+    `success` BOOLEAN NOT NULL,
+    `create_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `update_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`success`,`ip`,`login_id`),
+    CONSTRAINT FOREIGN KEY (`login_id`) REFERENCES `login` (`id`)
+) ENGINE=InnoDB COMMENT='Log of logins to discover login attack attempts. Has to be cleaned up by the services.';


### PR DESCRIPTION
We noticed a few hundred failed login attempts in a very short time which looks like a brute force password attack.

In order to detect and throttle such attempts, we need to log failed logins a) per ip and b) per user id. So we can see a) (distributed) attacks on a single account and b) single attacks across random accounts.

The idea is to store successful logins as well as failed ones. The api has to clear up the old attempts.

Logic could be as following:
A successful attempt on one account deletes older successfull logins on this account (aka only 1 successfull login attempt per account is stored). Failed login attempts have to be cleared out by the user (or are auto-cleared if the failed attempt count from the same ip is below a certain threshold)