### PR TITLE
Populate leaderboard_rating_journal

### DIFF
--- a/migrations/V95__populate_leaderboard_rating_journal.sql
+++ b/migrations/V95__populate_leaderboard_rating_journal.sql
@@ -12,7 +12,7 @@ INSERT INTO leaderboard_rating_journal (
         WHEN
           game_player_stats.score IN (-1, 0, 1)
           AND
-          game_stats.gameName LIKE "% Vs %" COLLATE utf8_bin
+          game_stats.gameName LIKE _utf8 "% Vs %" COLLATE utf8_bin
           AND
           (
             SELECT COUNT(*)

--- a/migrations/V95__populate_leaderboard_rating_journal.sql
+++ b/migrations/V95__populate_leaderboard_rating_journal.sql
@@ -28,8 +28,10 @@ INSERT INTO leaderboard_rating_journal (
             AND game_player_stats.color IN (1, 2)
             AND game_player_stats.score IN (-1, 0, 1)
           ) = 2
-          THEN (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
-        ELSE (SELECT id from leaderboard where leaderboard.technical_name = "global")
+        THEN
+          (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
+        ELSE
+          (SELECT id from leaderboard where leaderboard.technical_name = "global")
       END AS leaderboard_id,
       game_player_stats.mean,
       game_player_stats.deviation,
@@ -66,10 +68,11 @@ INSERT INTO leaderboard_rating_journal (
 )
 SELECT
     game_player_stats.id,
-    CASE
-      WHEN game_featuredMods.gamemod = "ladder1v1" THEN (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
-      ELSE (SELECT id from leaderboard where leaderboard.technical_name = "global")
-    END AS leaderboard_id,
+    IF(
+      game_featuredMods.gamemod = "ladder1v1",
+      (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1"),
+      (SELECT id from leaderboard where leaderboard.technical_name = "global")
+    ) AS leaderboard_id,
     game_player_stats.mean,
     game_player_stats.deviation,
     CASE

--- a/migrations/V95__populate_leaderboard_rating_journal.sql
+++ b/migrations/V95__populate_leaderboard_rating_journal.sql
@@ -9,35 +9,27 @@ INSERT INTO leaderboard_rating_journal (
   SELECT
       game_player_stats.id,
       CASE
-        WHEN game_stats.id < 1996398 THEN
-          CASE
-            WHEN 
-              game_player_stats.score IN (-1, 0, 1) 
-              AND
-              game_stats.gameName LIKE _utf8 "% Vs %" COLLATE utf8_bin
-              AND
-              (
-                SELECT COUNT(*)
-                FROM game_player_stats
-                WHERE game_player_stats.gameId = game_stats.id
-              ) = 2
-              AND
-              (
-                SELECT COUNT(*)
-                FROM game_player_stats
-                WHERE game_player_stats.gameId = game_stats.id
-                AND game_player_stats.AI = FALSE
-                AND game_player_stats.color IN (1, 2)
-                AND game_player_stats.score IN (-1, 0, 1)
-              ) = 2
-              THEN (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
-            ELSE (SELECT id from leaderboard where leaderboard.technical_name = "global")
-          END
-        ELSE
-          CASE
-            WHEN game_featuredMods.gamemod = "ladder1v1" THEN (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
-            ELSE (SELECT id from leaderboard where leaderboard.technical_name = "global")
-          END
+        WHEN
+          game_player_stats.score IN (-1, 0, 1)
+          AND
+          game_stats.gameName LIKE _utf8 "% Vs %" COLLATE utf8_bin
+          AND
+          (
+            SELECT COUNT(*)
+            FROM game_player_stats
+            WHERE game_player_stats.gameId = game_stats.id
+          ) = 2
+          AND
+          (
+            SELECT COUNT(*)
+            FROM game_player_stats
+            WHERE game_player_stats.gameId = game_stats.id
+            AND game_player_stats.AI = FALSE
+            AND game_player_stats.color IN (1, 2)
+            AND game_player_stats.score IN (-1, 0, 1)
+          ) = 2
+          THEN (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
+        ELSE (SELECT id from leaderboard where leaderboard.technical_name = "global")
       END AS leaderboard_id,
       game_player_stats.mean,
       game_player_stats.deviation,
@@ -52,6 +44,8 @@ INSERT INTO leaderboard_rating_journal (
       JOIN
         game_validity ON (game_stats.validity = game_validity.id)
     WHERE
+      game_stats.id < 1996398
+      AND
       game_player_stats.after_mean IS NOT NULL
       AND
       game_player_stats.after_deviation IS NOT NULL
@@ -60,4 +54,103 @@ INSERT INTO leaderboard_rating_journal (
       AND
       game_featuredMods.gamemod IN ("faf", "ladder1v1")
     ORDER BY game_player_stats.id
+;
+
+INSERT INTO leaderboard_rating_journal (
+  game_player_stats_id,
+  leaderboard_id,
+  rating_mean_before,
+  rating_deviation_before,
+  rating_mean_after,
+  rating_deviation_after
+)
+SELECT
+    game_player_stats.id,
+    CASE
+      WHEN game_featuredMods.gamemod = "ladder1v1" THEN (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
+      ELSE (SELECT id from leaderboard where leaderboard.technical_name = "global")
+    END AS leaderboard_id,
+    game_player_stats.mean,
+    game_player_stats.deviation,
+    CASE
+      WHEN game_player_stats.after_mean IS NOT NULL
+        THEN game_player_stats.after_mean
+      WHEN (
+        SELECT inner_game_player_stats.mean
+        FROM game_player_stats inner_game_player_stats
+        JOIN game_stats inner_game_stats
+        ON (inner_game_player_stats.gameId = inner_game_stats.id)
+        WHERE
+          inner_game_stats.id > game_stats.id
+          AND
+          inner_game_player_stats.playerId = game_player_stats.playerId
+          AND
+          inner_game_stats.gameMod = game_stats.gameMod
+        ORDER BY game_stats.id
+        LIMIT 1
+      ) IS NOT NULL
+        THEN (
+          SELECT inner_game_player_stats.mean
+          FROM game_player_stats inner_game_player_stats
+          JOIN game_stats inner_game_stats
+          ON (inner_game_player_stats.gameId = inner_game_stats.id)
+          WHERE
+            inner_game_stats.id > game_stats.id
+            AND
+            inner_game_player_stats.playerId = game_player_stats.playerId
+            AND
+            inner_game_stats.gameMod = game_stats.gameMod
+          ORDER BY game_stats.id
+          LIMIT 1
+        )
+      ELSE  game_player_stats.mean
+    END AS after_mean,
+    CASE
+      WHEN game_player_stats.after_deviation IS NOT NULL
+        THEN game_player_stats.after_deviation
+      WHEN (
+        SELECT inner_game_player_stats.deviation
+        FROM game_player_stats inner_game_player_stats
+        JOIN game_stats inner_game_stats
+        ON (inner_game_player_stats.gameId = inner_game_stats.id)
+        WHERE
+          inner_game_stats.id > game_stats.id
+          AND
+          inner_game_player_stats.playerId = game_player_stats.playerId
+          AND
+          inner_game_stats.gameMod = game_stats.gameMod
+        ORDER BY game_stats.id
+        LIMIT 1
+      ) IS NOT NULL
+        THEN (
+          SELECT inner_game_player_stats.deviation
+          FROM game_player_stats inner_game_player_stats
+          JOIN game_stats inner_game_stats
+          ON (inner_game_player_stats.gameId = inner_game_stats.id)
+          WHERE
+            inner_game_stats.id > game_stats.id
+            AND
+            inner_game_player_stats.playerId = game_player_stats.playerId
+            AND
+            inner_game_stats.gameMod = game_stats.gameMod
+          ORDER BY game_stats.id
+          LIMIT 1
+        )
+      ELSE game_player_stats.deviation
+    END AS after_deviation
+  FROM
+    game_stats
+    JOIN
+      game_player_stats ON (game_player_stats.gameId = game_stats.id)
+    JOIN
+      game_featuredMods ON (game_stats.gameMod = game_featuredMods.id)
+    JOIN
+      game_validity ON (game_stats.validity = game_validity.id)
+  WHERE
+    game_stats.id >= 1996398
+    AND
+    game_validity.message = "Valid"
+    AND
+    game_featuredMods.gamemod IN ("faf", "ladder1v1")
+  ORDER BY game_player_stats.id
 ;

--- a/migrations/V95__populate_leaderboard_rating_journal.sql
+++ b/migrations/V95__populate_leaderboard_rating_journal.sql
@@ -14,7 +14,7 @@ INSERT INTO leaderboard_rating_journal (
             WHEN 
               game_player_stats.score IN (-1, 0, 1) 
               AND
-              game_stats.gameName LIKE "% Vs %"
+              game_stats.gameName LIKE _utf8 "% Vs %" COLLATE utf8_bin
               AND
               (
                 SELECT COUNT(*)
@@ -35,7 +35,7 @@ INSERT INTO leaderboard_rating_journal (
           END
         ELSE
           CASE
-            WHEN game_featuredMods.gamemod = "ladder_1v1" THEN (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
+            WHEN game_featuredMods.gamemod = "ladder1v1" THEN (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
             ELSE (SELECT id from leaderboard where leaderboard.technical_name = "global")
           END
       END AS leaderboard_id,
@@ -49,13 +49,15 @@ INSERT INTO leaderboard_rating_journal (
         game_player_stats ON (game_player_stats.gameId = game_stats.id)
       JOIN
         game_featuredMods ON (game_stats.gameMod = game_featuredMods.id)
+      JOIN
+        game_validity ON (game_stats.validity = game_validity.id)
     WHERE
       game_player_stats.after_mean IS NOT NULL
       AND
       game_player_stats.after_deviation IS NOT NULL
       AND
-      game_stats.validity = 0
+      game_validity.message = "Valid"
       AND
-      game_featuredMods.gamemod IN ("faf", "ladder_1v1")
+      game_featuredMods.gamemod IN ("faf", "ladder1v1")
     ORDER BY game_player_stats.id
 ;

--- a/migrations/V95__populate_leaderboard_rating_journal.sql
+++ b/migrations/V95__populate_leaderboard_rating_journal.sql
@@ -1,0 +1,61 @@
+INSERT INTO leaderboard_rating_journal (
+  game_player_stats_id, 
+  leaderboard_id, 
+  rating_mean_before, 
+  rating_deviation_before, 
+  rating_mean_after, 
+  rating_deviation_after
+)
+  SELECT
+      game_player_stats.id,
+      CASE
+        WHEN game_stats.id < 1996398 THEN
+          CASE
+            WHEN 
+              game_player_stats.score IN (-1, 0, 1) 
+              AND
+              game_stats.gameName LIKE "% Vs %"
+              AND
+              (
+                SELECT COUNT(*)
+                FROM game_player_stats
+                WHERE game_player_stats.gameId = game_stats.id
+              ) = 2
+              AND
+              (
+                SELECT COUNT(*)
+                FROM game_player_stats
+                WHERE game_player_stats.gameId = game_stats.id
+                AND game_player_stats.AI = FALSE
+                AND game_player_stats.color IN (1, 2)
+                AND game_player_stats.score IN (-1, 0, 1)
+              ) = 2
+              THEN (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
+            ELSE (SELECT id from leaderboard where leaderboard.technical_name = "global")
+          END
+        ELSE
+          CASE
+            WHEN game_featuredMods.gamemod = "ladder_1v1" THEN (SELECT id from leaderboard where leaderboard.technical_name = "ladder_1v1")
+            ELSE (SELECT id from leaderboard where leaderboard.technical_name = "global")
+          END
+      END AS leaderboard_id,
+      game_player_stats.mean,
+      game_player_stats.deviation,
+      game_player_stats.after_mean,
+      game_player_stats.after_deviation
+    FROM
+      game_stats
+      JOIN
+        game_player_stats ON (game_player_stats.gameId = game_stats.id)
+      JOIN
+        game_featuredMods ON (game_stats.gameMod = game_featuredMods.id)
+    WHERE
+      game_player_stats.after_mean IS NOT NULL
+      AND
+      game_player_stats.after_deviation IS NOT NULL
+      AND
+      game_stats.validity = 0
+      AND
+      game_featuredMods.gamemod IN ("faf", "ladder_1v1")
+    ORDER BY game_player_stats.id
+;

--- a/migrations/V95__populate_leaderboard_rating_journal.sql
+++ b/migrations/V95__populate_leaderboard_rating_journal.sql
@@ -12,7 +12,7 @@ INSERT INTO leaderboard_rating_journal (
         WHEN
           game_player_stats.score IN (-1, 0, 1)
           AND
-          game_stats.gameName LIKE _utf8 "% Vs %" COLLATE utf8_bin
+          game_stats.gameName LIKE "% Vs %" COLLATE utf8_bin
           AND
           (
             SELECT COUNT(*)


### PR DESCRIPTION
To fill `leaderboard_rating_journal` with entries from old games, we only need to determine the `leaderboard_id` column, currently either the one belonging to `global` or to `ladder_1v1`.

For newer games (since mid 2014) that is easy to do by looking at the featured mod ("faf" or "ladder_1v1"), but for earlier games the ladder mod doesn't exist and we try to guess it instead.
Here "earlier" means `game_stats.id < 1996398" or `game_stats.startTime < "2014-03-22 12:59:25"`.

On my laptop the query takes about 10 minutes, so I'm not sure how feasible it is as a migration, but maybe this gives you at least the chance to give me feedback on the SQL (much of which I had to acquire for this :sweat_smile: But now at least I know that terrible things happen if you don't include an `ON` in the join, outside of sqlalchemy.)

`game_stats.id = 1996398` is the first game using the `ladder1v1` mod.
However, the first game using that mod with a `game_player_stats` entry whose `after_mean` is not `NULL` is `4401810`, two years later. In between these two, there are about 275k valid "ladder1v1" games, none of them having the `after_mean` or `after_deviation` set in their `game_player_stats` rows.
After `4401810` we have about 400k  valid "ladder1v1" games with `after_mean` set and only about 1k where it is `NULL`.

There are only about 250 games we mark as ladder games before using the featured mod, few enough that I can scroll through them and not see any false positives, judging from the game name.

Questions
 1. Is `game_featuredMods.gamemod IN ("faf", "ladder1v1")` too restrictive for games with `global` rating?
 1. There is only a couple of hundred games passing the WHERE clause with `game_stats.id < 1996398", is that expected?
 1.  Maybe the `ORDER BY` is superfluous? It would be nice if the order of `leaderboard_rating_journal.id` still reflects the historical timeline

ToDo
 - [x] Check that `game_stats.id = 1996398` is the first game with featured mod `ladder_1v1` or something reasonable like that
 - [ ] Do some sanity checks