### PR TITLE
Add matchmaker_queue_game table

### DIFF
--- a/migrations/V103__link_matchmaker_games_to_originating_queue.sql
+++ b/migrations/V103__link_matchmaker_games_to_originating_queue.sql
@@ -1,0 +1,9 @@
+CREATE TABLE matchmaker_queue_game
+(
+  id                  INT(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  matchmaker_queue_id INT(10) UNSIGNED NOT NULL,
+  game_stats_id       INT(10) UNSIGNED NOT NULL,
+  FOREIGN KEY (matchmaker_queue_id) REFERENCES matchmaker_queue (id),
+  FOREIGN KEY (game_stats_id) REFERENCES game_stats (id),
+  UNIQUE INDEX (game_stats_id, matchmaker_queue_id)
+);

--- a/migrations/V104__link_matchmaker_games_to_originating_queue.sql
+++ b/migrations/V104__link_matchmaker_games_to_originating_queue.sql
@@ -1,9 +1,8 @@
 CREATE TABLE matchmaker_queue_game
 (
-  id                  INT(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
   matchmaker_queue_id INT(10) UNSIGNED NOT NULL,
   game_stats_id       INT(10) UNSIGNED NOT NULL,
   FOREIGN KEY (matchmaker_queue_id) REFERENCES matchmaker_queue (id),
   FOREIGN KEY (game_stats_id) REFERENCES game_stats (id),
-  UNIQUE INDEX (game_stats_id, matchmaker_queue_id)
+  PRIMARY KEY (game_stats_id, matchmaker_queue_id)
 );


### PR DESCRIPTION
Adds a new m:n relationship table for linking games to their originating matchmaker queue, as suggested in https://github.com/FAForever/server/issues/599.
This is needed to properly find the recent game history per queue to avoid map repetition.
PR https://github.com/FAForever/server/pull/654 depends on this table.
