### PR TITLE
Fix rating sign

### DIFF
--- a/migrations/V105__fix_rating_signedness.sql
+++ b/migrations/V105__fix_rating_signedness.sql
@@ -1,0 +1,10 @@
+-- Mean may be negative (signed) but deviation must be positive (unsigned)
+ALTER TABLE leaderboard_rating MODIFY deviation FLOAT UNSIGNED NOT NULL;
+
+ALTER TABLE leaderboard_rating_journal
+  MODIFY rating_deviation_before FLOAT UNSIGNED NOT NULL,
+  MODIFY rating_deviation_after FLOAT UNSIGNED NOT NULL;
+
+ALTER TABLE game_player_stats
+  MODIFY mean FLOAT NOT NULL,
+  MODIFY after_deviation FLOAT UNSIGNED;


### PR DESCRIPTION
For some reason the `mean` field on `game_player_stats` is set to unsigned, even though negative mean is OK. (Even `after_mean` is signed...). Really we want to make sure that DEVIATION is unsigned. Technically speaking I think deviation must always be strictly positive, deviation of 0 will cause issues, but I'm not sure it's possible or necessary to enforce that in MySQL.

The `ladder1v1_rating` and `global_rating` tables both allow negative deviation, and so do their corresponding rank views, but since those tables are more or less deprecated anyways I just left them.