### PR TITLE
Migrate to MariaDB

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       faf-db:
-        image: mysql:5.7
+        image: mariadb:10.6
         ports:
           - 3306:3306
         options: >-

--- a/migrations/V121__mariadb_migration_workarounds.sql
+++ b/migrations/V121__mariadb_migration_workarounds.sql
@@ -1,0 +1,5 @@
+-- MariaDB imports trip over generated columns, therefore we temporarily remove them
+alter table avatars_list drop column url;
+alter table global_rating drop column rating;
+alter table ladder1v1_rating drop column rating;
+alter table leaderboard_rating drop column rating;

--- a/migrations/V122__revert_workarounds.sql
+++ b/migrations/V122__revert_workarounds.sql
@@ -1,0 +1,5 @@
+-- MariaDB imports trip over generated columns, therefore we temporarily remove them
+alter table avatars_list add url varchar(255) as (concat('https://content.faforever.com/faf/avatars/',`filename`));;
+alter table global_rating add rating float as ((`mean` - (3 * `deviation`))) stored;
+alter table ladder1v1_rating add rating float as ((`mean` - (3 * `deviation`))) stored;
+alter table leaderboard_rating add rating float as ((`mean` - (3 * `deviation`))) stored;


### PR DESCRIPTION
- [ ] Test full import of prod data and correct functionality on test server.
- [ ] For deployment on prod [dropping the flyway table](https://github.com/FAForever/db/blob/feature/maria-db/ci/test-migrations.sh#L11) must not be forgotten