### PR TITLE
Support more casual game modes

### DIFF
--- a/migrations/R__060_leaderboard.sql
+++ b/migrations/R__060_leaderboard.sql
@@ -4,12 +4,13 @@
 -- If you want to edit an existing or add a new leaderboard, just append it to the SQL command and run flyway migrate.
 -- Leaderboards are handled dynamically. You can add leaderboards and reference them from the matchmaker.
 
-INSERT INTO `leaderboard` (id, technical_name, name_key, description_key) VALUES
-(1,'global','leaderboard.global.name','leaderboard.global.description'),
-(2,'ladder_1v1','leaderboard.ladder_1v1.name','leaderboard.ladder_1v1.description'),
-(3,'tmm_2v2','leaderboard.tmm_2v2.name','leaderboard.tmm_2v2.description')
+INSERT INTO `leaderboard` (id, initializer_id, technical_name, name_key, description_key) VALUES
+(1,NULL,'global','leaderboard.global.name','leaderboard.global.description'),
+(2,NULL,'ladder_1v1','leaderboard.ladder_1v1.name','leaderboard.ladder_1v1.description'),
+(3,1,'tmm_2v2','leaderboard.tmm_2v2.name','leaderboard.tmm_2v2.description')
 -- add new row above this comment (don't forget to append the comma to the previous one)
 ON DUPLICATE KEY UPDATE
+    initializer_id=VALUES(initializer_id),
     technical_name=VALUES(technical_name),
     name_key=VALUES(name_key),
     description_key=VALUES(description_key);

--- a/migrations/R__070_matchmaker_queue.sql
+++ b/migrations/R__070_matchmaker_queue.sql
@@ -4,14 +4,15 @@
 -- If you want to edit an existing or add a new matchmaker queue, just append it to the SQL command and run flyway migrate.
 -- Matchmaker queues are handled dynamically. If they are enabled they will show up. (The map pool is managed by privileged users.)
 
-INSERT INTO `matchmaker_queue` (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, enabled) VALUES
-(1,'ladder1v1',6,2,'matchmaker_queue.ladder1v1',1,1),
-(2,'tmm2v2',0,3,'matchmaker_queue.tmm2v2.name',2,1)
+INSERT INTO `matchmaker_queue` (id, technical_name, featured_mod_id, leaderboard_id, name_key, teams, team_size, enabled) VALUES
+(1,'ladder1v1',6,2,'matchmaker_queue.ladder1v1',2,1,1),
+(2,'tmm2v2',0,3,'matchmaker_queue.tmm2v2.name',2,2,1)
 -- add new row above this comment (don't forget to append the comma to the previous one)
 ON DUPLICATE KEY UPDATE
     technical_name=VALUES(technical_name),
     featured_mod_id=VALUES(featured_mod_id),
     leaderboard_id=VALUES(leaderboard_id),
     name_key=VALUES(name_key),
+    teams=VALUES(teams),
     team_size=VALUES(team_size),
     enabled=VALUES(enabled);

--- a/migrations/V110__casual_matchmaker_options.sql
+++ b/migrations/V110__casual_matchmaker_options.sql
@@ -1,0 +1,14 @@
+ALTER TABLE matchmaker_queue
+  ADD COLUMN teams TINYINT UNSIGNED NOT NULL DEFAULT 2
+    COMMENT 'Number of teams. 0 = FFA, 1 = Coop/Survival, 2 = Normal game. Some values might not be implemented.'
+;
+
+
+CREATE TABLE matchmaker_queue_mod_version
+(
+  matchmaker_queue_id INT(10) UNSIGNED NOT NULL,
+  mod_version_id      MEDIUMINT(8) UNSIGNED NOT NULL,
+  FOREIGN KEY (matchmaker_queue_id) REFERENCES matchmaker_queue (id),
+  FOREIGN KEY (mod_version_id) REFERENCES mod_version (id),
+  PRIMARY KEY (mod_version_id, matchmaker_queue_id)
+);

--- a/migrations/V111__leaderboard_initialization.sql
+++ b/migrations/V111__leaderboard_initialization.sql
@@ -1,0 +1,5 @@
+ALTER TABLE leaderboard
+  ADD COLUMN initializer_id SMALLINT(5) UNSIGNED DEFAULT NULL
+    COMMENT 'Initialize rating based on existing entries from another leaderboard.',
+  ADD FOREIGN KEY (initializer_id) REFERENCES leaderboard (id)
+;


### PR DESCRIPTION
This would allow us to add more team setups like FFA, or cooperative/survival as well as linking mods from the vault and not just featured mods.

The mods setup will require implementation on both the client and server, but since the client already has a mod manager I think it should be fairly easy.

Also adds a column to `leaderboard` for specifying which existing leaderboard rating to use when creating a rating for the first time. https://github.com/FAForever/server/issues/724