### PR TITLE
Add new leaderboards and matchmaker queues for 4v4

### DIFF
--- a/migrations/R__060_leaderboard.sql
+++ b/migrations/R__060_leaderboard.sql
@@ -7,7 +7,9 @@
 INSERT INTO `leaderboard` (id, initializer_id, technical_name, name_key, description_key) VALUES
 (1,NULL,'global','leaderboard.global.name','leaderboard.global.description'),
 (2,NULL,'ladder_1v1','leaderboard.ladder_1v1.name','leaderboard.ladder_1v1.description'),
-(3,1,'tmm_2v2','leaderboard.tmm_2v2.name','leaderboard.tmm_2v2.description')
+(3,1,'tmm_2v2','leaderboard.tmm_2v2.name','leaderboard.tmm_2v2.description'),
+(4,1,'tmm_4v4_full_share','leaderboard.tmm_4v4_full_share.name','leaderboard.tmm_4v4_full_share.description'),
+(5,1,'tmm_4v4_share_until_death','leaderboard.tmm_4v4_share_until_death.name','leaderboard.tmm_4v4_share_until_death.description')
 -- add new row above this comment (don't forget to append the comma to the previous one)
 ON DUPLICATE KEY UPDATE
     initializer_id=VALUES(initializer_id),

--- a/migrations/R__070_matchmaker_queue.sql
+++ b/migrations/R__070_matchmaker_queue.sql
@@ -7,8 +7,8 @@
 INSERT INTO `matchmaker_queue` (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, params, enabled) VALUES
 (1,'ladder1v1',6,2,'matchmaker_queue.ladder1v1',1,'UnitCap: 1500',1),
 (2,'tmm2v2',0,3,'matchmaker_queue.tmm2v2.name',2,NULL,1),
-(3,'tmm4v4FullShare',0,4,'matchmaker_queue.tmm4v4FullShare.name',4,NULL,0),
-(4,'tmm4v4ShareUntilDeath',0,5,'matchmaker_queue.tmm4v4ShareUntilDeath.name',4,'Share: ShareUntilDeath',0)
+(3,'tmm4v4_full_share',0,4,'matchmaker_queue.tmm4v4_full_share.name',4,NULL,0),
+(4,'tmm4v4_share_until_death',0,5,'matchmaker_queue.tmm4v4_share_until_death.name',4,'Share: ShareUntilDeath',0)
 -- add new row above this comment (don't forget to append the comma to the previous one)
 ON DUPLICATE KEY UPDATE
     technical_name=VALUES(technical_name),

--- a/migrations/R__070_matchmaker_queue.sql
+++ b/migrations/R__070_matchmaker_queue.sql
@@ -5,7 +5,7 @@
 -- Matchmaker queues are handled dynamically. If they are enabled they will show up. (The map pool is managed by privileged users.)
 
 INSERT INTO `matchmaker_queue` (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, params, enabled) VALUES
-(1,'ladder1v1',6,2,'matchmaker_queue.ladder1v1',1,'UnitCap: 1500',1),
+(1,'ladder1v1',0,2,'matchmaker_queue.ladder1v1',1,'UnitCap: 1500',1),
 (2,'tmm2v2',0,3,'matchmaker_queue.tmm2v2.name',2,NULL,1),
 (3,'tmm4v4_full_share',0,4,'matchmaker_queue.tmm4v4_full_share.name',4,NULL,0),
 (4,'tmm4v4_share_until_death',0,5,'matchmaker_queue.tmm4v4_share_until_death.name',4,'Share: ShareUntilDeath',0)

--- a/migrations/R__070_matchmaker_queue.sql
+++ b/migrations/R__070_matchmaker_queue.sql
@@ -5,10 +5,10 @@
 -- Matchmaker queues are handled dynamically. If they are enabled they will show up. (The map pool is managed by privileged users.)
 
 INSERT INTO `matchmaker_queue` (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, params, enabled) VALUES
-(1,'ladder1v1',0,2,'matchmaker_queue.ladder1v1',1,'UnitCap: 1500',1),
+(1,'ladder1v1',0,2,'matchmaker_queue.ladder1v1',1,'{"GameOptions":{"UnitCap":1500}}',1),
 (2,'tmm2v2',0,3,'matchmaker_queue.tmm2v2.name',2,NULL,1),
 (3,'tmm4v4_full_share',0,4,'matchmaker_queue.tmm4v4_full_share.name',4,NULL,0),
-(4,'tmm4v4_share_until_death',0,5,'matchmaker_queue.tmm4v4_share_until_death.name',4,'Share: ShareUntilDeath',0)
+(4,'tmm4v4_share_until_death',0,5,'matchmaker_queue.tmm4v4_share_until_death.name',4,'{"GameOptions":{"Share":"ShareUntilDeath"}}',0)
 -- add new row above this comment (don't forget to append the comma to the previous one)
 ON DUPLICATE KEY UPDATE
     technical_name=VALUES(technical_name),

--- a/migrations/R__070_matchmaker_queue.sql
+++ b/migrations/R__070_matchmaker_queue.sql
@@ -7,8 +7,8 @@
 INSERT INTO `matchmaker_queue` (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, params, enabled) VALUES
 (1,'ladder1v1',6,2,'matchmaker_queue.ladder1v1',1,'UnitCap: 1500',1),
 (2,'tmm2v2',0,3,'matchmaker_queue.tmm2v2.name',2,NULL,1),
-(3,'tmm4v4FullShare',0,4,'matchmaker_queue.tmm4v4FullShare.name',4,NULL,1),
-(4,'tmm4v4ShareUntilDeath',0,5,'matchmaker_queue.tmm4v4ShareUntilDeath.name',4,'Share: ShareUntilDeath',1)
+(3,'tmm4v4FullShare',0,4,'matchmaker_queue.tmm4v4FullShare.name',4,NULL,0),
+(4,'tmm4v4ShareUntilDeath',0,5,'matchmaker_queue.tmm4v4ShareUntilDeath.name',4,'Share: ShareUntilDeath',0)
 -- add new row above this comment (don't forget to append the comma to the previous one)
 ON DUPLICATE KEY UPDATE
     technical_name=VALUES(technical_name),

--- a/migrations/R__070_matchmaker_queue.sql
+++ b/migrations/R__070_matchmaker_queue.sql
@@ -4,9 +4,11 @@
 -- If you want to edit an existing or add a new matchmaker queue, just append it to the SQL command and run flyway migrate.
 -- Matchmaker queues are handled dynamically. If they are enabled they will show up. (The map pool is managed by privileged users.)
 
-INSERT INTO `matchmaker_queue` (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, enabled) VALUES
-(1,'ladder1v1',6,2,'matchmaker_queue.ladder1v1',1,1),
-(2,'tmm2v2',0,3,'matchmaker_queue.tmm2v2.name',2,1)
+INSERT INTO `matchmaker_queue` (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, params, enabled) VALUES
+(1,'ladder1v1',6,2,'matchmaker_queue.ladder1v1',1,'UnitCap: 1500',1),
+(2,'tmm2v2',0,3,'matchmaker_queue.tmm2v2.name',2,NULL,1),
+(3,'tmm4v4FullShare',0,4,'matchmaker_queue.tmm4v4FullShare.name',4,NULL,1),
+(4,'tmm4v4ShareUntilDeath',0,5,'matchmaker_queue.tmm4v4ShareUntilDeath.name',4,'Share: ShareUntilDeath',1)
 -- add new row above this comment (don't forget to append the comma to the previous one)
 ON DUPLICATE KEY UPDATE
     technical_name=VALUES(technical_name),

--- a/migrations/R__070_matchmaker_queue.sql
+++ b/migrations/R__070_matchmaker_queue.sql
@@ -5,7 +5,7 @@
 -- Matchmaker queues are handled dynamically. If they are enabled they will show up. (The map pool is managed by privileged users.)
 
 INSERT INTO `matchmaker_queue` (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, params, enabled) VALUES
-(1,'ladder1v1',0,2,'matchmaker_queue.ladder1v1',1,'{"GameOptions":{"UnitCap":1500}}',1),
+(1,'ladder1v1',0,2,'matchmaker_queue.ladder1v1',1,NULL,1),
 (2,'tmm2v2',0,3,'matchmaker_queue.tmm2v2.name',2,NULL,1),
 (3,'tmm4v4_full_share',0,4,'matchmaker_queue.tmm4v4_full_share.name',4,NULL,0),
 (4,'tmm4v4_share_until_death',0,5,'matchmaker_queue.tmm4v4_share_until_death.name',4,'{"GameOptions":{"Share":"ShareUntilDeath"}}',0)


### PR DESCRIPTION
I also set the 1v1 unit cap to 1500.
I didn't find anything for the map pools. Are they completely managed by the moderator client?