### PR TITLE
Closes #306 Update flyway version as MariaDB 10.5 is not supported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM flyway/flyway:7.15.0-alpine
+FROM flyway/flyway:9.16-alpine
 
 ENV FLYWAY_EDITION community
 


### PR DESCRIPTION
Closes #306 Update flyway version as MariaDB 10.5 is not supported