### PR TITLE
Don't allow players to friend or foe themselves

### DIFF
--- a/migrations/V134__friends_and_foes_constraint.sql
+++ b/migrations/V134__friends_and_foes_constraint.sql
@@ -1,0 +1,5 @@
+DELETE FROM friends_and_foes WHERE user_id = subject_id;
+
+ALTER TABLE friends_and_foes
+ADD CONSTRAINT friends_and_foes_cannot_reference_self
+CHECK (user_id <> subject_id);


### PR DESCRIPTION
It doesn't make sense to allow friend/foe relationships to ones self. Are we supposed to hide our own chat messages from ourselves if we are our own foe? Are we supposed to be disallowed from playing a game with ourselves?

I think the client already isn't supposed to allow you to do this, but I can see in the server logs that sometimes this is attempted. I would be curious to know the number of self referential rows there are on prod.

```
select count(*) from friends_and_foes where user_id=subject_id;
```