### PR TITLE
Add enum value for decapitation game mode

### DIFF
--- a/migrations/V136__add_decapitation_victory_condition.sql
+++ b/migrations/V136__add_decapitation_victory_condition.sql
@@ -1,0 +1,26 @@
+ALTER TABLE game_stats
+  MODIFY `gameType` enum(
+    '0',
+    '1',
+    '2',
+    '3',
+    'DEMORALIZATION',
+    'DOMINATION',
+    'ERADICATION',
+    'SANDBOX',
+    'DECAPITATION'
+  ) NOT NULL;
+
+UPDATE game_stats set `gameType` = 'DEMORALIZATION' where `gameType` = '0';
+UPDATE game_stats set `gameType` = 'DOMINATION' where `gameType` = '1';
+UPDATE game_stats set `gameType` = 'ERADICATION' where `gameType` = '2';
+UPDATE game_stats set `gameType` = 'SANDBOX' where `gameType` = '3';
+
+ALTER TABLE game_stats
+  MODIFY `gameType` enum(
+    'DEMORALIZATION',
+    'DOMINATION',
+    'ERADICATION',
+    'SANDBOX',
+    'DECAPITATION'
+  ) NOT NULL;


### PR DESCRIPTION
Needed for https://github.com/FAForever/fa/issues/5347

Can we change the enum to be the actual string names of the victory conditions without it messing up the historical data? Seems pretty bad to me to be using stringified integers.