### PR TITLE
added description column to the avatars_list table

### DIFF
--- a/migrations/V137__add_avatar_description.sql
+++ b/migrations/V137__add_avatar_description.sql
@@ -1,0 +1,3 @@
+ALTER TABLE avatars_list
+  ADD COLUMN avatar_text_description MEDIUMTEXT;
+


### PR DESCRIPTION
Added description column to the avatars_list table through adding a file to the migrations directory.
This is in service of: Add avatar text description column #321
https://github.com/FAForever/db/issues/321

There is currently no specific branch for the feature on the repository so I set the request to the develop branch.
I set the datatype to mediumtext as I don't know how big you would want the descriptions to be. Varchar may give you better performance but fewer characters.

Feedback on the code and my use of git is appreciated