### PR TITLE
Add id column as primary key for unique_id_users

### DIFF
--- a/migrations/V140__add_id_to_unique_id_users.sql
+++ b/migrations/V140__add_id_to_unique_id_users.sql
@@ -1,0 +1,5 @@
+alter table unique_id_users
+    add id int auto_increment first,
+    drop primary key,
+    add constraint unique_id_users_pk
+        primary key (id);


### PR DESCRIPTION
This is required for Elide to use this as a entity and get access to the timestamps.