### PR TITLE
Enforce uniqueness on unique_id_users

### DIFF
--- a/migrations/V141__enforce_uniqueness_unique_id_users.sql
+++ b/migrations/V141__enforce_uniqueness_unique_id_users.sql
@@ -1,0 +1,5 @@
+-- Dropping the primary key in V140 unintentionally also removed the unique constraint on user_id and uniqueid_hash
+
+alter table unique_id_users
+    add constraint unique_id_users_pk
+        unique (user_id, uniqueid_hash);


### PR DESCRIPTION
Dropping the primary key in V140 unintentionally also removed the unique constraint on user_id and uniqueid_hash