### PR TITLE
Add login.avatar_id FK for selected avatar

### DIFF
--- a/migrations/V143__login_avatar_fk.sql
+++ b/migrations/V143__login_avatar_fk.sql
@@ -4,7 +4,7 @@
 -- reconciler to repair any drift.
 
 ALTER TABLE login
-  ADD COLUMN avatar_id mediumint(8) unsigned DEFAULT NULL,
+  ADD COLUMN avatar_id int(11) unsigned DEFAULT NULL,
   ADD CONSTRAINT fk_login_avatar
     FOREIGN KEY (avatar_id) REFERENCES avatars_list (id)
     ON DELETE SET NULL ON UPDATE CASCADE;

--- a/migrations/V143__login_avatar_fk.sql
+++ b/migrations/V143__login_avatar_fk.sql
@@ -1,0 +1,15 @@
+-- Add a single "currently selected avatar" reference on the login table.
+-- The legacy `avatars.selected` flag is kept (and still user-writable) for
+-- backwards compatibility; the API mirrors both sides on writes and exposes a
+-- reconciler to repair any drift.
+
+ALTER TABLE login
+  ADD COLUMN avatar_id mediumint(8) unsigned DEFAULT NULL,
+  ADD CONSTRAINT fk_login_avatar
+    FOREIGN KEY (avatar_id) REFERENCES avatars_list (id)
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Backfill from the legacy selected flag.
+UPDATE login l
+  JOIN avatars a ON a.idUser = l.id AND a.selected = 1
+SET l.avatar_id = a.idAvatar;


### PR DESCRIPTION
Partial solution of https://github.com/FAForever/db/issues/102

## Summary
- Adds a nullable `avatar_id` column on `login` with FK to `avatars_list(id)` (ON DELETE SET NULL, ON UPDATE CASCADE).
- Backfills `login.avatar_id` from existing `avatars.selected = 1` rows.
- The legacy `avatars.selected` flag is intentionally kept and remains user-writable for backwards compatibility. The faf-java-api change (separate PR) mirrors both columns on writes and exposes a reconciler to repair drift.

## Test plan
- [ ] Run Flyway against a snapshot of prod; verify `login.avatar_id` is populated for every user that previously had exactly one `avatars.selected = 1` row.
- [ ] Verify users with no selected avatar end up with `avatar_id IS NULL`.
- [ ] Verify FK behavior: deleting an `avatars_list` row sets the referencing `login.avatar_id` to NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database architecture to establish new data relationships
  * Migrated existing data to align with restructured database organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->