### PR TITLE
Add map_version.folder_name column, derive filename

### DIFF
--- a/migrations/V144__map_version_folder_name.sql
+++ b/migrations/V144__map_version_folder_name.sql
@@ -1,0 +1,30 @@
+-- Make the map folder name a real, indexable column.
+--
+-- Previously only `filename` (e.g. `maps/scmp_001.v0001.zip`) was stored, and the
+-- API derived the folder name from it in-memory in a @PostLoad enricher. That made
+-- `versions.folderName == X` filters impossible to push down to SQL, forcing a full
+-- table scan + in-memory enrichment on every map lookup (~5s per request).
+--
+-- `folder_name` (e.g. `scmp_001.v0001`) becomes the source of truth. `filename` is
+-- kept as a VIRTUAL generated column so external readers (faf-server, replay server)
+-- and existing API clients continue to see the identical `maps/<folder>.zip` value.
+
+-- 1. add the new source-of-truth column
+ALTER TABLE map_version ADD COLUMN folder_name varchar(200) NULL AFTER filename;
+
+-- 2. backfill, prefix/suffix-agnostic (mirrors the old Java extraction:
+--    part after the last '/', up to '.zip')
+UPDATE map_version
+SET folder_name = SUBSTRING_INDEX(SUBSTRING_INDEX(filename, '/', -1), '.zip', 1);
+
+-- 3. enforce constraints on the new column
+ALTER TABLE map_version
+  MODIFY folder_name varchar(200) NOT NULL,
+  ADD UNIQUE KEY folder_name (folder_name);
+
+-- 4. drop the old real filename column (drops its now-redundant UNIQUE key) and
+--    re-add it as a VIRTUAL generated column (no storage, no index needed). Its
+--    uniqueness is implied by the UNIQUE folder_name it is derived from.
+ALTER TABLE map_version DROP COLUMN filename;
+ALTER TABLE map_version
+  ADD COLUMN filename varchar(200) AS (CONCAT('maps/', folder_name, '.zip')) VIRTUAL;

--- a/test-data.sql
+++ b/test-data.sql
@@ -120,25 +120,25 @@ values
 (14, 'SCMP_014', 'FFA', 'skirmish', 3, 1),
 (15, 'SCMP_015', 'FFA', 'skirmish', 3, 1);
 
-insert into map_version (id, description, max_players, width, height, version, filename, hidden, map_id)
+insert into map_version (id, description, max_players, width, height, version, folder_name, hidden, map_id)
 values
-(1, 'SCMP 001', 8, 1024, 1024, 1, 'maps/scmp_001.zip', 0, 1),
-(2, 'SCMP 002', 8, 1024, 1024, 1, 'maps/scmp_002.zip', 0, 2),
-(3, 'SCMP 003', 8, 1024, 1024, 1, 'maps/scmp_003.zip', 0, 3),
-(4, 'SCMP 004', 8, 1024, 1024, 1, 'maps/scmp_004.zip', 0, 4),
-(5, 'SCMP 005', 8, 2048, 2048, 1, 'maps/scmp_005.zip', 0, 5),
-(6, 'SCMP 006', 8, 1024, 1024, 1, 'maps/scmp_006.zip', 0, 6),
-(7, 'SCMP 007', 8, 512, 512, 1, 'maps/scmp_007.zip', 0, 7),
-(8, 'SCMP 008', 8, 1024, 1024, 1, 'maps/scmp_008.zip', 0, 8),
-(9, 'SCMP 009', 8, 1024, 1024, 1, 'maps/scmp_009.zip', 0, 9),
-(10, 'SCMP 010', 8, 1024, 1024, 1, 'maps/scmp_010.zip', 0, 10),
-(11, 'SCMP 011', 8, 2048, 2048, 1, 'maps/scmp_011.zip', 0, 11),
-(12, 'SCMP 012', 8, 256, 256, 1, 'maps/scmp_012.zip', 0, 12),
-(13, 'SCMP 013', 8, 256, 256, 1, 'maps/scmp_013.zip', 0, 13),
-(14, 'SCMP 014', 8, 1024, 1024, 1, 'maps/scmp_014.zip', 0, 14),
-(15, 'SCMP 015', 8, 512, 512, 1, 'maps/scmp_015.zip', 0, 15),
-(16, 'SCMP 015', 8, 512, 512, 2, 'maps/scmp_015.v0002.zip', 0, 15),
-(17, 'SCMP 015', 8, 512, 512, 3, 'maps/scmp_015.v0003.zip', 0, 15);
+(1, 'SCMP 001', 8, 1024, 1024, 1, 'scmp_001', 0, 1),
+(2, 'SCMP 002', 8, 1024, 1024, 1, 'scmp_002', 0, 2),
+(3, 'SCMP 003', 8, 1024, 1024, 1, 'scmp_003', 0, 3),
+(4, 'SCMP 004', 8, 1024, 1024, 1, 'scmp_004', 0, 4),
+(5, 'SCMP 005', 8, 2048, 2048, 1, 'scmp_005', 0, 5),
+(6, 'SCMP 006', 8, 1024, 1024, 1, 'scmp_006', 0, 6),
+(7, 'SCMP 007', 8, 512, 512, 1, 'scmp_007', 0, 7),
+(8, 'SCMP 008', 8, 1024, 1024, 1, 'scmp_008', 0, 8),
+(9, 'SCMP 009', 8, 1024, 1024, 1, 'scmp_009', 0, 9),
+(10, 'SCMP 010', 8, 1024, 1024, 1, 'scmp_010', 0, 10),
+(11, 'SCMP 011', 8, 2048, 2048, 1, 'scmp_011', 0, 11),
+(12, 'SCMP 012', 8, 256, 256, 1, 'scmp_012', 0, 12),
+(13, 'SCMP 013', 8, 256, 256, 1, 'scmp_013', 0, 13),
+(14, 'SCMP 014', 8, 1024, 1024, 1, 'scmp_014', 0, 14),
+(15, 'SCMP 015', 8, 512, 512, 1, 'scmp_015', 0, 15),
+(16, 'SCMP 015', 8, 512, 512, 2, 'scmp_015.v0002', 0, 15),
+(17, 'SCMP 015', 8, 512, 512, 3, 'scmp_015.v0003', 0, 15);
 
 INSERT INTO `coop_map` (`type`, `name`, `description`, `version`, `filename`)
 VALUES (0, 'FA Campaign map', 'A map from the FA campaign', 2, 'maps/scmp_coop_123.v0002.zip'),


### PR DESCRIPTION
## Why

Every `/data/map` request that filters on `versions.folderName` (e.g. the client's "find latest version by folder name" lookup) takes a flat ~5s. Root cause: in the API `folderName` is a transient/computed attribute derived in-memory from `filename` in a `@PostLoad` enricher, so Elide **cannot** translate `versions.folderName == X` into SQL. It falls back to loading and enriching the entire `map_version` table on every request and filtering in memory.

`filename` (`maps/<folder>.zip`) just stores the folder name with a fixed prefix/suffix. This migration makes the folder name a real, indexable column.

## What

- Add `folder_name` (`NOT NULL`, `UNIQUE`) as the new source of truth and backfill it from `filename` (prefix/suffix-agnostic).
- Drop the old real `filename` column and re-add it as a **VIRTUAL generated column** `CONCAT('maps/', folder_name, '.zip')` — no storage, recomputed on read.

`filename` is kept (generated) purely for backwards compatibility: faf-server (`game_service`, `ladder_service`, coop lookups), faf-rust-replayserver (`get_game_stat_row`) and any API clients reading the `filename` attribute keep seeing the identical value with no changes. Its `UNIQUE` index is dropped as redundant — it is a 1:1 function of the already-`UNIQUE` `folder_name`.

## Coordinated change

The API side (entity mapping, upload service, enricher) lives in `faf-java-api` on branch `feature/map-version-folder-name`, which pins the migrations image to `v144`. This PR must be released as `v144` for that branch's integration tests to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database schema structure to improve data consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->